### PR TITLE
Remove unnecessary locking.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ option(BUILD_TESTING "set ON to build testing framework" ON)
 # this will find the CMake configuration for the GROMACS libraries we need and define the CMake library objects
 # Gromacs::gmxapi
 find_package(gmxapi
-             0.0.4 REQUIRED CONFIG
+             0.0.5 REQUIRED CONFIG
              PATHS "$ENV{GROMACS_DIR}"
              )
 

--- a/src/cpp/ensemblepotential.h
+++ b/src/cpp/ensemblepotential.h
@@ -301,9 +301,6 @@ class EnsembleHarmonic
         double k_;
         /// Smoothing factor: width of Gaussian interpolation for histogram
         double sigma_;
-
-        std::mutex samples_mutex_;
-        std::mutex windows_mutex_;
 };
 
 /*!

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -111,8 +111,7 @@ SOL         4055
     with gmx.context.DefaultContext(system.workflow) as session:
         session.run()
 
-    # gmx 0.0.4
-    assert gmx.__version__ == '0.0.4'
+    assert gmx.__version__ == '0.0.5'
     md = gmx.workflow.from_tpr(tpr_filename)
 
     context = gmx.context.ParallelArrayContext(md)
@@ -200,8 +199,7 @@ SOL         4055
         from gmx.data import tpr_filename
     print("Testing plugin potential with input file {}".format(os.path.abspath(tpr_filename)))
 
-    # gmx 0.0.4
-    assert gmx.__version__ == '0.0.4'
+    assert gmx.__version__ == '0.0.5'
     md = gmx.workflow.from_tpr([tpr_filename])
 
     # Create a WorkElement for the potential
@@ -294,8 +292,7 @@ SOL         4055
         from gmx.data import tpr_filename
     logger.info("Testing plugin potential with input file {}".format(os.path.abspath(tpr_filename)))
 
-    # gmx 0.0.4
-    assert gmx.__version__ == '0.0.4'
+    assert gmx.__version__ == '0.0.5'
     md = gmx.workflow.from_tpr([tpr_filename, tpr_filename])
 
     # Create a WorkElement for the potential
@@ -325,6 +322,3 @@ SOL         4055
     context = gmx.context.ParallelArrayContext(md)
     with context as session:
         session.run()
-
-
-


### PR DESCRIPTION
Two mutexes were in place to provide thread safety in the call-back,
but the thread safety should be guaranteed by the gmxapi framework, so
these were an unnecessary performance expense.