### PR TITLE
gmxapi-45 Formal AllReduce operation

### DIFF
--- a/src/cpp/ensemblepotential.cpp
+++ b/src/cpp/ensemblepotential.cpp
@@ -219,6 +219,8 @@ void EnsembleHarmonic::callback(gmx::Vector v,
         // Get global reduction (sum) and checkpoint.
         assert(temp_window != nullptr);
         // Todo: in reduce function, give us a mean instead of a sum.
+        // Note: with additional infrastructure, the call-back ends here, the ensemble reduce operation has a dependency
+        // on new_window, and the force calculation has a dependency on the result of the reduce operation.
         ensemble.reduce(*new_window,
                         temp_window.get());
 


### PR DESCRIPTION
mark a spot where the call-back can be broken up when data flow can
manage the dependencies of callback -> ensemble reduce -> calculate.