### PR TITLE
Resolve an unsafe lambda capture.

### DIFF
--- a/src/pythonmodule/export_plugin.cpp
+++ b/src/pythonmodule/export_plugin.cpp
@@ -300,12 +300,12 @@ class EnsembleRestraintBuilder
             assert(py::hasattr(context_, "ensemble_update"));
             // make a local copy of the Python object so we can capture it in the lambda
             auto update = context_.attr("ensemble_update");
-            // Make a bindings-independent callable with standardizeable signature.
-            auto name = py::str(name_);
+            // Make a callable with standardizeable signature.
+            const std::string name{name_};
             auto functor = [update, name](const plugin::Matrix<double>& send,
                                     plugin::Matrix<double>* receive)
             {
-                update(send, receive, name);
+                update(send, receive, py::str(name));
             };
 
             // To use a reduce function on the Python side, we need to provide it with a Python buffer-like object,


### PR DESCRIPTION
At least in Python 3, the py::str(std::string s) behavior does not seem
to result in a reference-counted copy of the provided string and results
in a double-free problem on at least some platforms when the then-owner
of the function object is destroyed (it outlives the original string).

To resolve, we copy the data member string to a local (non-member)
const std::string, which the lambda function seems to capture
appropriately and is properly cleaned up. The lambda function is defined
in a translation unit that has access to py::str(), so we're fine there.