### PR TITLE
Allow tests to tolerate unclean working directories.

### DIFF
--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -112,7 +112,7 @@ SOL         4055
         session.run()
 
     assert gmx.version.api_is_at_least(0,0,5)
-    md = gmx.workflow.from_tpr(tpr_filename)
+    md = gmx.workflow.from_tpr(tpr_filename, append_output=False)
 
     context = gmx.context.ParallelArrayContext(md)
     with context as session:
@@ -200,7 +200,7 @@ SOL         4055
     print("Testing plugin potential with input file {}".format(os.path.abspath(tpr_filename)))
 
     assert gmx.version.api_is_at_least(0,0,5)
-    md = gmx.workflow.from_tpr([tpr_filename])
+    md = gmx.workflow.from_tpr([tpr_filename], append_output=False)
 
     # Create a WorkElement for the potential
     #potential = gmx.core.TestModule()
@@ -293,7 +293,7 @@ SOL         4055
     logger.info("Testing plugin potential with input file {}".format(os.path.abspath(tpr_filename)))
 
     assert gmx.version.api_is_at_least(0,0,5)
-    md = gmx.workflow.from_tpr([tpr_filename, tpr_filename])
+    md = gmx.workflow.from_tpr([tpr_filename, tpr_filename], append_output=False)
 
     # Create a WorkElement for the potential
     #potential = gmx.core.TestModule()


### PR DESCRIPTION
This change is necessary to allow us to test the port of GROMACS
master to gromacs-gmxapi. It should be merged as soon as it is
confirmed not to break anything and then merged into devel and
the 0.0.6 release branch.

Newer code bases have a problem with multiple tests run in the same
working directory. The symptom is that the GROMACS simulation will shut
down cleanly, but with an exit code of 1, and console output that
includes:

"Fatal error: Checksum wrong for 'md.log'. The file has been replaced or
its contents have been modified. Cannot do appending because of this
condition."

The pytest "cleandir" wrapper should have taken care of this, and will
be addressed in a separate change. But reusing the working directories
in these particular tests is not a problem, so this commit instructs
the test simulations not to try to append output to existing files.