### PR TITLE
use make_unique from C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(sample_restraint VERSION 0.0.7)
 # versions of GROMACS. If building from the command line, you can specify a Python executable with the PYTHON_EXECUTABLE
 # variable. For instance, to make sure you are building for your default Python, cmake -DPYTHON_EXECUTABLE=`which python`.
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
 # CMake modules are in a subdirectory to keep this file cleaner

--- a/src/cpp/ensemblepotential.cpp
+++ b/src/cpp/ensemblepotential.cpp
@@ -17,6 +17,7 @@
 #include <cassert>
 #include <cmath>
 
+#include <memory>
 #include <vector>
 
 #include "gmxapi/context.h"
@@ -189,7 +190,7 @@ void EnsembleHarmonic::callback(gmx::Vector v,
     if (t >= nextWindowUpdateTime_)
     {
         // Get next histogram array, recycling old one if available.
-        std::unique_ptr<Matrix<double>> new_window = gmx::compat::make_unique<Matrix<double>>(1,
+        std::unique_ptr<Matrix<double>> new_window = std::make_unique<Matrix<double>>(1,
                                                                                               nBins_);
         std::unique_ptr<Matrix<double>> temp_window;
         if (windows_.size() == nWindows_)
@@ -201,7 +202,7 @@ void EnsembleHarmonic::callback(gmx::Vector v,
         }
         else
         {
-            auto new_temp_window = gmx::compat::make_unique<Matrix<double>>(1,
+            auto new_temp_window = std::make_unique<Matrix<double>>(1,
                                                                             nBins_);
             assert(new_temp_window);
             temp_window.swap(new_temp_window);
@@ -334,7 +335,7 @@ makeEnsembleParams(size_t nbins,
                    double k,
                    double sigma)
 {
-    using gmx::compat::make_unique;
+    using std::make_unique;
     auto params = make_unique<ensemble_input_param_type>();
     params->nBins = nbins;
     params->binWidth = binWidth;

--- a/src/cpp/ensemblepotential.h
+++ b/src/cpp/ensemblepotential.h
@@ -30,8 +30,6 @@
 #include "gromacs/restraint/restraintpotential.h"
 #include "gromacs/utility/real.h"
 
-// We do not require C++14, so we have a back-ported C++14 feature for C++11 code.
-#include "make_unique.h"
 #include "sessionresources.h"
 
 namespace plugin

--- a/src/cpp/sessionresources.cpp
+++ b/src/cpp/sessionresources.cpp
@@ -6,6 +6,8 @@
 
 #include <cassert>
 
+#include <memory>
+
 #include "gmxapi/exceptions.h"
 #include "gmxapi/md/mdsignals.h"
 

--- a/src/cpp/sessionresources.h
+++ b/src/cpp/sessionresources.h
@@ -18,8 +18,6 @@
 #include "gromacs/restraint/restraintpotential.h"
 #include "gromacs/utility/real.h"
 
-#include "make_unique.h"
-
 namespace plugin
 {
 

--- a/src/pythonmodule/export_plugin.cpp
+++ b/src/pythonmodule/export_plugin.cpp
@@ -12,6 +12,8 @@
 
 #include <cassert>
 
+#include <memory>
+
 #include "gmxapi/exceptions.h"
 #include "gmxapi/md.h"
 #include "gmxapi/md/mdmodule.h"
@@ -19,7 +21,6 @@
 
 #include "harmonicpotential.h"
 #include "ensemblepotential.h"
-#include "make_unique.h"
 
 // Make a convenient alias to save some typing...
 namespace py = pybind11;
@@ -405,7 +406,7 @@ std::unique_ptr<HarmonicRestraintBuilder> createHarmonicBuilder(const py::object
  */
 std::unique_ptr<EnsembleRestraintBuilder> createEnsembleBuilder(const py::object element)
 {
-    using gmx::compat::make_unique;
+    using std::make_unique;
     auto builder = make_unique<EnsembleRestraintBuilder>(element);
     return builder;
 }


### PR DESCRIPTION
gmx::compat::make_unique will be removed since the C++14 requirements on GROMACS 2020 clients imply the availability of std::make_unique