### PR TITLE
Check for uninitialized py::object

### DIFF
--- a/src/pythonmodule/export_plugin.cpp
+++ b/src/pythonmodule/export_plugin.cpp
@@ -224,6 +224,14 @@ class HarmonicRestraintBuilder
          */
         void build(py::object graph)
         {
+            if (!subscriber_)
+            {
+                return;
+            }
+            else
+            {
+                if (!py::hasattr(subscriber_, "potential")) throw gmxapi::ProtocolError("Invalid subscriber");
+            }
             auto potential = PyRestraint<plugin::HarmonicModule>::create(site1Index_,
                                                                          site2Index_,
                                                                          equilibriumPosition_,
@@ -327,6 +335,15 @@ class EnsembleRestraintBuilder
          */
         void build(py::object graph)
         {
+            if (!subscriber_)
+            {
+                return;
+            }
+            else
+            {
+                if (!py::hasattr(subscriber_, "potential")) throw gmxapi::ProtocolError("Invalid subscriber");
+            }
+
             // Temporarily subvert things to get quick-and-dirty solution for testing.
             // Need to capture Python communicator and pybind syntax in closure so EnsembleResources
             // can just call with matrix arguments.
@@ -392,7 +409,7 @@ class EnsembleRestraintBuilder
  * \param element WorkElement provided through Context
  * \return ownership of new builder object
  */
-std::unique_ptr<HarmonicRestraintBuilder> createHarmonicBuilder(const py::object element)
+std::unique_ptr<HarmonicRestraintBuilder> createHarmonicBuilder(const py::object& element)
 {
     std::unique_ptr<HarmonicRestraintBuilder> builder{new HarmonicRestraintBuilder(element)};
     return builder;


### PR DESCRIPTION
The build() function that instantiates the potential and publishes it to the MD subscriber did not check whether there was an actual subscriber object to publish to. A `pybind11::object` is initialized with a nullptr member rather than None or a reference-counted Python object, so this sort of access causes a segmentation fault instead of a Python error. We could consider initializing `py::object` members to `None`, but a simple check suffices for now. In the longer run, we are reworking this protocol and one goal should be to avoid holding Python references at all.

I also checked the kassonlab/gmxapi sources and don't see any similarly unsafe uses of `py::object`, so I think this PR resolves kassonlab/gmxapi#226
