### PR TITLE
Remove explicit default of overridden destructor.

### DIFF
--- a/src/cpp/sessionresources.h
+++ b/src/cpp/sessionresources.h
@@ -232,8 +232,6 @@ class RestraintModule : public gmxapi::MDModule // consider names
 
         };
 
-        ~RestraintModule() override = default;
-
         /*!
          * \brief Implement gmxapi::MDModule interface to get module name.
          *


### PR DESCRIPTION
The template for plugin::RestraintModule<> derives from gmxapi::MDModule,
which defines a virtual destructor. The template used the `default`
syntax to attempt to generate a trivial destructor. This seems
unnecessary, and seems to cause problems in some compilers, for which
the destructor of the template instantiations never get generated or
otherwise can't be found at link time.

The problem goes away by either defining an actual destructor body
(`~Restraint() override {};`) or just leaving out the explicit
destructor declaration.